### PR TITLE
Remove date from posts (text and URL)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ description: > # ignore newlines until next field
   Libere tempo, automatize tarefas.
 
 show_excerpts: true
-permalink: pretty
+permalink: /:title/
 lang: pt-br
 
 minima:

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,14 +5,6 @@ layout: default
 
   <header class="post-header">
     <h1 class="post-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
-    <p class="post-meta">
-      <time class="dt-published" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">
-        {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
-        {{ page.date | date: date_format }}
-      </time>
-      {%- if page.author -%}
-        • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span class="p-author h-card" itemprop="name">{{ page.author | escape }}</span></span>
-      {%- endif -%}</p>
   </header>
 
   <div class="post-content e-content" itemprop="articleBody">


### PR DESCRIPTION
Keep date only on index page. The idea is to avoid the impression that
texts will follow a cronological order or be time sensitive. I expect to
keep texts as most "up-to-date" as possible.